### PR TITLE
Fix to keep the Repo Active

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -3,9 +3,17 @@ on:
   schedule:
     - cron: "0 0 1 * *" # Runs at midnight on the 1st of every month
   workflow_dispatch:
+
+permissions:
+  contents: write
+
 jobs:
-  keepalive:
+  commit:
     runs-on: ubuntu-latest
     steps:
-      - name: Do nothing
-        run: echo "Keeping repository active"
+      - uses: actions/checkout@v4
+      - run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git commit --allow-empty -m "Scheduled keepalive commit"
+          git push

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,10 @@
+name: Keep Repository Active
+on:
+  schedule:
+    - cron: "0 0 1 * *" # Runs at midnight on the 1st of every month
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Do nothing
+        run: echo "Keeping repository active"

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -2,6 +2,7 @@ name: Keep Repository Active
 on:
   schedule:
     - cron: "0 0 1 * *" # Runs at midnight on the 1st of every month
+  workflow_dispatch:
 jobs:
   keepalive:
     runs-on: ubuntu-latest

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -25,7 +25,7 @@ jobs:
     environment: AFDevOrgRenew
     strategy:
       matrix:
-        org: [AMD_AGENTFORCE_DEV_ORG_URL_1, AMD_AGENTFORCE_DEV_ORG_URL_2]
+        org: [AMD_AGENTFORCE_DEV_ORG_URL_1]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -2,42 +2,42 @@ name: Renew Agentforce Dev Org Lease
 run-name: ${{ github.actor }} triggered dev org renewal build
 #on: [push]
 on:
-    schedule:
-        - cron: "30 20 * * MON"
-    workflow_dispatch:
+  schedule:
+    - cron: "30 20 * * MON"
+  workflow_dispatch:
 jobs:
-    dev-org-renew:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  ref: main
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: "20"
-            - name: "Install CLI"
-              run: npm install @salesforce/cli --location=global
-            - run: sf --version
+  dev-org-renew:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - name: "Install CLI"
+        run: npm install @salesforce/cli --location=global
+      - run: sf --version
 
-    authenticate-orgs:
-        needs: dev-org-renew
-        runs-on: ubuntu-latest
-        environment: AFDevOrgRenew
-        strategy:
-            matrix:
-                org: [AGENTFORCE_DEV_ORG_URL, DEVEDITION_ORG1]
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  ref: main
-            - name: "Install CLI"
-              run: npm install @salesforce/cli --location=global
-            - name: "Authenticate to ${{ matrix.org }} org"
-              env:
-                  SECRET_VALUE: ${{ secrets[matrix.org] }}
-              run: |
-                  echo "$SECRET_VALUE" > ./${{ matrix.org }}.txt
-                  sf org login sfdx-url -f ./${{ matrix.org }}.txt -a ${{ matrix.org }} -d
-            - name: 'Query data'
-              run: |
-                  sf data query --query "select name from organization" -o ${{ matrix.org }}
+  authenticate-orgs:
+    needs: dev-org-renew
+    runs-on: ubuntu-latest
+    environment: AFDevOrgRenew
+    strategy:
+      matrix:
+        org: [AMD_AGENTFORCE_DEV_ORG_URL_1, AMD_AGENTFORCE_DEV_ORG_URL_2]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: "Install CLI"
+        run: npm install @salesforce/cli --location=global
+      - name: "Authenticate to ${{ matrix.org }} org"
+        env:
+          SECRET_VALUE: ${{ secrets[matrix.org] }}
+        run: |
+          echo "$SECRET_VALUE" > ./${{ matrix.org }}.txt
+          sf org login sfdx-url -f ./${{ matrix.org }}.txt -a ${{ matrix.org }} -d
+      - name: "Query data"
+        run: |
+          sf data query --query "select name from organization" -o ${{ matrix.org }}

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -25,7 +25,7 @@ jobs:
     environment: AFDevOrgRenew
     strategy:
       matrix:
-        org: [AMD_AGENTFORCE_DEV_ORG_URL]
+        org: [AMD_AGENTFORCE_DEV_ORG_URL_1, AMD_AGENTFORCE_DEV_ORG_URL_2]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -25,7 +25,7 @@ jobs:
     environment: AFDevOrgRenew
     strategy:
       matrix:
-        org: [AMD_AGENTFORCE_DEV_ORG_URL_1]
+        org: [AMD_AGENTFORCE_DEV_ORG_URL]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -25,7 +25,7 @@ jobs:
     environment: AFDevOrgRenew
     strategy:
       matrix:
-        org: [AMD_AGENTFORCE_DEV_ORG_URL_1, AMD_AGENTFORCE_DEV_ORG_URL_2]
+        org: [AGENTFORCE_DEV_ORG_URL, DEVEDITION_ORG1]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Added an additional workflow YML file to keep the repo active. This workflow runs 1st of every month to keep the repo active so that, GitHub doesn't suspend trigger after a continuous inactivity of 60 days in the repo.
Issue Link - #3 

